### PR TITLE
Fix issue #3

### DIFF
--- a/spuce.rb
+++ b/spuce.rb
@@ -9,7 +9,7 @@ class Spuce < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", "-DCMAKE_PREFIX_PATH=/usr/local/opt/qt5", *std_cmake_args
+      system "cmake", "..", "-DBUILD_TESTING=OFF", "-DCMAKE_PREFIX_PATH=/usr/local/opt/qt5", *std_cmake_args
       system "make", "install" # if this fails, try separate make/make install steps
     end
   end


### PR DESCRIPTION
Somehow spuce does not link when testing is enabled. My guess is that
because the testing relies on Python there is some issue with linking
spuce and Python for testing.
This issue is resolved when testing is disabled.